### PR TITLE
Fix/500

### DIFF
--- a/gen3utils/main.py
+++ b/gen3utils/main.py
@@ -36,7 +36,7 @@ def validate(manifest_files):
             with open(f_name, "r") as f:
                 cdis_manifest = json.loads(f.read())
             validate_manifest(cdis_manifest, requirements)
-        except Exception as e:
+        except AssertionError as e:
             logger.error("{}: {}".format(type(e).__name__, e))
             failed_validation = True
     if failed_validation:

--- a/gen3utils/validation_config.yaml
+++ b/gen3utils/validation_config.yaml
@@ -46,9 +46,9 @@ versions:
       max: '2.2.1'
   #indexed higher than 2.0.0 requires fence higher than 2.0.0
   #centralized auth
-- indexd: '2.0.0'
-  needs: 
-    fence: '3.0.0'
+# - indexd: '2.0.0'
+#   needs:
+#     fence: '3.0.0'
   #peregrine:2.0.0 needs arborist higher than 2.2.1
   #peregrine integration with arborist needs arborist endpoint /auth/mapping
 - peregrine: '2.0.0'

--- a/gen3utils/validation_config.yaml
+++ b/gen3utils/validation_config.yaml
@@ -1,74 +1,78 @@
-#The commons and the microservice which doesn't need validation. 
+#######################
+# VALIDATIONS TO SKIP #
+#######################
+# The commons and the microservice which don't need validation.
+
 avoid:
   qa-mickey.planx-pla.net:
-  - 'sower'
+  - "sower"
 
-#Validation for the manifest blocks required by some services
+
+####################
+# BLOCK VALIDATION #
+####################
+# Validation for the manifest blocks required by some services
+# The version should contains at least min or max.
 # /!\ max is < not <=. min is >=
+
 block:
-  #Arborist higher than 2.0.0 requires arborist block to have deployment_version
-  #The version should contains at least min or max.
+  # Arborist higher than 2.0.0 requires arborist block to have deployment_version
   arborist:
     version:
-      min: '2.0.0'
-      #max: '3.0.0'
+      min: "2.0.0"
+      #max: "3.0.0"
     has: deployment_version
-  #hatchery requires hatchery block to have sidecar
+  # hatchery requires hatchery block to have sidecar
   hatchery:
     has: sidecar
-  #sower requires a sower block
-  sower: 'true'
-  #guppy requires a guppy block
-  guppy: 'true'
+  # sower requires a sower block
+  sower: "true"
+  # guppy requires a guppy block
+  guppy: "true"
 
-#Validation for service couples that need matching versions
+
+######################
+# VERSION VALIDATION #
+######################
+# Validation for service couples that need matching versions
 # /!\ max is < not <=. min is >=
+
 versions:
-  #fence higher than 3.0.0 requires arborist higher than 2.0.0
-  #centralized auth 
-- fence: '3.0.0'
+- fence: "3.0.0"
   needs:
-    arborist: '2.0.0'
-  #fence higher than 4.6.0 requires arborist higher than 2.3.0
-  #synapse integration
-- fence: '4.6.0'
+    arborist: "2.0.0"
+  desc: "centralized auth. fence higher than 3.0.0 requires arborist higher than 2.0.0"
+- fence: "4.6.0"
   needs:
-    arborist: '2.3.0'
-  #Fence 4.4.x requires Arborist == 2.2.0
-  #Arborist 2.2.0 adds the PUT /policy/{policyID} endpoint (but keeps the old one)
-  #Arborist 2.2.1 PUT policy endpoints no longer implicitly upsert
+    arborist: "2.3.0"
+  desc: "synapse integration. fence higher than 4.6.0 requires arborist higher than 2.3.0"
 - fence: 
-    min: '4.4.0'
-    max: '4.5.0'
+    min: "4.4.0"
+    max: "4.5.0"
   needs:
     arborist:
-      min: '2.2.0'
-      max: '2.2.1'
-  #indexed higher than 2.0.0 requires fence higher than 2.0.0
-  #centralized auth
-# - indexd: '2.0.0'
-#   needs:
-#     fence: '3.0.0'
-  #peregrine:2.0.0 needs arborist higher than 2.2.1
-  #peregrine integration with arborist needs arborist endpoint /auth/mapping
-- peregrine: '2.0.0'
+      min: "2.2.0"
+      max: "2.2.1"
+  desc: "Fence 4.4.x requires Arborist == 2.2.0. Arborist 2.2.0 adds the PUT /policy/{policyID} endpoint (but keeps the old one). Arborist 2.2.1 PUT policy endpoints no longer implicitly upsert"
+- peregrine: "2.0.0"
   needs:
-    arborist: '2.1.0'
-  #hatchery requires wts, manifestservice and ambassador
+    arborist: "2.1.0"
+  desc: "peregrine integration with arborist needs arborist endpoint /auth/mapping (arborist higher than 2.2.1)"
 - hatchery: "*"
   needs:
     wts: "*"
     ambassador: "*"
-  #sower requires guppy 
+  desc: "hatchery requires wts, manifestservice and ambassador"
 - sower: "*"
   needs:
     guppy: "*"
-  #guppy requires aws-es-proxy 
+  desc: "sower requires guppy"
 - guppy: "*"
   needs:
     aws-es-proxy: "*"
-  #tube requires spark and aws-es-proxy 
+  desc: "guppy requires aws-es-proxy"
 - tube: "*"
   needs:
     spark: "*"
     aws-es-proxy: "*"
+  desc: "tube requires spark and aws-es-proxy"

--- a/tests/test_manifest_validation.py
+++ b/tests/test_manifest_validation.py
@@ -48,6 +48,10 @@ def test_versions_validation_needs(validation_config):
     ok = versions_validation(versions_block, validation_config["versions"])
     assert not ok, "fence 4.6.1 + arborist 1.0.0 should not pass validation"
 
+    versions_block = {"fence": "quay.io/cdis/fence:4.6.1"}
+    ok = versions_validation(versions_block, validation_config["versions"])
+    assert not ok, "fence 4.6.1 + no arborist should not pass validation"
+
     versions_block = {
         "fence": "quay.io/cdis/fence:4.4.4",
         "arborist": "quay.io/cdis/arborist:2.2.0",

--- a/tests/test_manifest_validation_config.py
+++ b/tests/test_manifest_validation_config.py
@@ -1,0 +1,13 @@
+def test_min_max(validation_config):
+    message = "For now, we do not handle versions validation with either min or max but not both - either fix the config or update the validation code to handle it: {}"
+    for requirement in validation_config.get("versions"):
+        for key, details in requirement.items():
+            if key != "needs":
+                assert ("min" in details and "max" in details) or (
+                    "min" not in details and "max" not in details
+                ), message.format(requirement)
+            else:
+                for need_details in details.values():
+                    assert ("min" in need_details and "max" in need_details) or (
+                        "min" not in need_details and "max" not in need_details
+                    ), message.format(requirement)

--- a/tests/test_manifest_validation_config.py
+++ b/tests/test_manifest_validation_config.py
@@ -11,3 +11,10 @@ def test_min_max(validation_config):
                     assert ("min" in need_details and "max" in need_details) or (
                         "min" not in need_details and "max" not in need_details
                     ), message.format(requirement)
+
+
+def test_description(validation_config):
+    for requirement in validation_config.get("versions"):
+        assert requirement.get(
+            "desc"
+        ), 'Missing description of requirement for "{}"'.format(requirement)


### PR DESCRIPTION
### Bug Fixes
- Fail validation with a useful error message if the service needed is not in the manifest

### Improvements
- Do not catch all exceptions, so that we get a stack trace in case of unexpected exception
- Add unit test for the manifest validation configuration
- Enforce writing descriptions of requirements
