### PR TITLE
fix(NDE portal)

### DIFF
--- a/gen3utils/main.py
+++ b/gen3utils/main.py
@@ -62,10 +62,12 @@ def validate_etl_mapping(etl_mapping_file, manifest_file):
         recorded_errors = validate_mapping(dictionary_url, etl_mapping_file)
 
         if recorded_errors:
-            print("ETL mapping validation failed:")
+            print("  ETL mapping validation failed:")
             for err in recorded_errors:
-                print("- {}".format(err))
+                print("  - {}".format(err))
             exit(1)
+        else:
+            print("  OK!")
 
 
 @main.command()

--- a/tests/test_deployment_changes.py
+++ b/tests/test_deployment_changes.py
@@ -27,7 +27,7 @@ def test_compare(monkeypatch):
         "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",  # branch to ignore
     }
 
-    compared = compare_versions_blocks(old_versions, new_versions)
+    compared = compare_versions_blocks(old_versions, new_versions, True)
     print("Compared versions:", compared)
 
     assert "arborist" in compared


### PR DESCRIPTION
The portal version comparison could be improved later to really check the repo names. Right now this works because the only 2 options are data-portal and data-ecosystem-portal. We may want to improve this if we need to check dataguids and other websites


### Improvements
- Handle data-ecosystem-portal, and only compare portal versions if they are from the same repo
- Improve ETL mapping validation error reporting
