### PR TITLE
Services pinned on a release tag are not validated

### DIFF
--- a/gen3utils/deployment_changes/generate_comment.py
+++ b/gen3utils/deployment_changes/generate_comment.py
@@ -191,8 +191,8 @@ def get_deployment_changes(versions_dict, token, is_nde_portal):
         # only get the deployment changes if the new version is more
         # recent than the old version. ignore services on a branch
         if (
-            not version_is_branch(versions["old"])
-            and not version_is_branch(versions["new"])
+            not version_is_branch(versions["old"], release_tag_are_branches=False)
+            and not version_is_branch(versions["new"], release_tag_are_branches=False)
             and version.parse(versions["old"]) < version.parse(versions["new"])
         ):
             repo_name = service

--- a/gen3utils/manifest/manifest_validator.py
+++ b/gen3utils/manifest/manifest_validator.py
@@ -144,10 +144,16 @@ def manifest_version(manifest_versions, service):
                 return service_version
 
 
-def version_is_branch(version):
+def version_is_branch(version, release_tag_are_branches=True):
     """
     Args:
         version (string)
+        release_tag_are_branches (bool): whether release tags in format
+            <dddd.dd> should be considered branches or not.
+            - For manifest validation, we want to skip validation for release
+            tags because the semantic versions comparison would not work.
+            - For checking deployment changes, we do want release tags to be
+            included like other tags.
 
     Returns:
         bool: True if version only contains digits and dots BUT is
@@ -158,7 +164,7 @@ def version_is_branch(version):
     is_branch = not bool(reg.match(str(version)))
 
     # check if it's a release tag
-    if not is_branch:
+    if not is_branch and release_tag_are_branches:
         reg = re.compile("^[0-9]{4}.[0-9]{2}$")
         is_branch = bool(reg.match(str(version)))
 


### PR DESCRIPTION
Semantic version comparison doesn't work with release tags. Maybe we'll need a smarter way to validate with release tags in the future. Skipping validation for release tags for now

+ fix issue with "has" block being validated even when service is on branch

### New Features
- Services pinned on a release tag (format <dddd.dd>) are not validated during manifest versions validation, but are included when posting deployment changes
