### PR TITLE
don't parse version if it's a branch

### DIFF
--- a/gen3utils/manifest/manifest_validator.py
+++ b/gen3utils/manifest/manifest_validator.py
@@ -60,7 +60,7 @@ def validate_manifest_block(manifest, blocks_requirements):
     for service_name, block in blocks_requirements.items():
         if service_name in manifest["versions"]:
             # Validation for all services has requirement in validation_config.
-            block_requirement_version = manifest_version(
+            block_requirement_version = get_manifest_version(
                 manifest["versions"], service_name
             )
             is_branch = version_is_branch(block_requirement_version)
@@ -117,7 +117,7 @@ def validate_manifest_block(manifest, blocks_requirements):
     return ok
 
 
-def manifest_version(manifest_versions, service):
+def get_manifest_version(manifest_versions, service):
     """
     Get the service version from cdis-manifest
         Arg: 
@@ -129,7 +129,7 @@ def manifest_version(manifest_versions, service):
     for manifest_version in manifest_versions:
         if manifest_version == service:
             # if this fails, make sure you check the service is in the manifest before
-            # calling manifest_version()! it should never happen
+            # calling get_manifest_version()! it should never happen
             service_line = manifest_versions[service]
             service_version = service_line.split(":")[1]
             if version_is_branch(service_version):
@@ -138,6 +138,7 @@ def manifest_version(manifest_versions, service):
                         service, service_version
                     )
                 )
+                return service_version
             try:
                 return version.parse(service_version)
             except:
@@ -189,7 +190,7 @@ def versions_validation(manifest_versions, versions_requirements):
         requirement_list = versions_requirement["needs"]
         requirement_key_list = list(requirement_list.keys())
         requirement_key = list(versions_requirement)[0]
-        actual_version = manifest_version(manifest_versions, requirement_key)
+        actual_version = get_manifest_version(manifest_versions, requirement_key)
 
         if requirement_key in manifest_versions and not version_is_branch(
             actual_version
@@ -263,7 +264,7 @@ def version_requirement_validation(
 
     for required_service in requirement_key_list:
 
-        actual_version = manifest_version(versions_manifest, required_service)
+        actual_version = get_manifest_version(versions_manifest, required_service)
 
         if not actual_version:
             logger.error(

--- a/tests/test_manifest_validation.py
+++ b/tests/test_manifest_validation.py
@@ -1,25 +1,25 @@
 from gen3utils.manifest.manifest_validator import (
     validate_manifest_block,
     versions_validation,
-    manifest_version,
+    get_manifest_version,
     version_is_branch,
 )
 
 
-def test_manifest_version():
+def test_get_manifest_version():
     versions_block = {
         "indexd": "quay.io/cdis/indexd:1.0.0",
         "arborist": "quay.io/cdis/arborist:master",
         "fence": "quay.io/cdis/fence:feat_mybranch",
     }
 
-    indexd_version = manifest_version(versions_block, "indexd")
+    indexd_version = get_manifest_version(versions_block, "indexd")
     assert str(indexd_version) == "1.0.0"
 
-    arborist_version = manifest_version(versions_block, "arborist")
+    arborist_version = get_manifest_version(versions_block, "arborist")
     assert str(arborist_version) == "master"
 
-    fence_version = manifest_version(versions_block, "fence")
+    fence_version = get_manifest_version(versions_block, "fence")
     assert str(fence_version) == "feat_mybranch"
 
 
@@ -27,6 +27,12 @@ def test_service_is_on_branch():
     assert version_is_branch("master")
     assert version_is_branch("feat_new-thing")
     assert not version_is_branch("1.2.14.8")
+
+
+def test_release_tag():
+    versions_block = {"arborist": "quay.io/cdis/arborist:2020.02"}
+    assert get_manifest_version(versions_block, "arborist") == "2020.02"
+    assert version_is_branch("2020.02")
 
 
 def test_versions_validation_needs(manifest_validation_config):

--- a/tests/test_manifest_validation.py
+++ b/tests/test_manifest_validation.py
@@ -33,6 +33,7 @@ def test_release_tag():
     versions_block = {"arborist": "quay.io/cdis/arborist:2020.02"}
     assert get_manifest_version(versions_block, "arborist") == "2020.02"
     assert version_is_branch("2020.02")
+    assert not version_is_branch("2020.02", release_tag_are_branches=False)
 
 
 def test_versions_validation_needs(manifest_validation_config):


### PR DESCRIPTION
`version.parse("2020.02")` returns `"2020.2"` and messes up the logic next time we try to check if the version is a branch by matching it to pattern `dddd.dd`. So avoid parsing the version if it's a branch

Add unit test for release tags

### Bug Fixes
- Do not try to parse version if it's a branch