### PR TITLE
Fix for COVID-19 ETLs

### DIFF
--- a/gen3utils/deployment_changes/generate_comment.py
+++ b/gen3utils/deployment_changes/generate_comment.py
@@ -205,7 +205,7 @@ def get_deployment_changes(versions_dict, token, is_nde_portal):
                 repo_name = "gen3-spark"
             elif service == "wts":
                 repo_name = "workspace-token-service"
-            elif service == "covid19-etl":
+            elif service.startswith("covid19-") and service.endswith("-etl"):
                 repo_name = "covid19-tools"
 
             args = Gen3GitArgs("uc-cdis/" + repo_name, versions["old"], versions["new"])


### PR DESCRIPTION
### Improvements
- Map all 'covid19-*-etl' service keys to 'covid19-tools' repo