### PR TITLE
Allow 'source_node' in ETLMapping

### DIFF
--- a/gen3utils/etl/etl_validator.py
+++ b/gen3utils/etl/etl_validator.py
@@ -163,7 +163,10 @@ def validate_name_src(json_obj, path, recorded_errors, nodes_with_props):
         )
     else:
         path_items = path.split(".")
-        if fn != "count" and src not in nodes_with_props.get(path_items[-1], []):
+        builtin_fields = ["source_node"]
+        valid_fields = nodes_with_props.get(path_items[-1], [])
+        valid_fields.extend(builtin_fields)
+        if fn != "count" and src not in valid_fields:
             recorded_errors.append(
                 FieldError(
                     'src field "{}" (declared in "{}" "{}") is not found in given dictionary.'.format(


### PR DESCRIPTION
Tube 0.4.1 allows a special `source_node` prop to be added to collector / file ETLMappings (https://github.com/uc-cdis/tube/releases/tag/0.4.1). The `source_node` prop isn't present on the dictionary, which was causing the the gen3utils etlMapping checks to fail. This commit patches the etlMapping check to allow `source_node` as a valid prop even if it isn't present in the dictionary.

### Improvements
- Allow built-in 'source_node' prop in ETLMapping

### Dependency updates


### Deployment changes

