### PR TITLE
Update etlMapping validation to work with tube >= 0.4.0/2020.10

### DIFF
--- a/gen3utils/deployment_changes/generate_comment.py
+++ b/gen3utils/deployment_changes/generate_comment.py
@@ -124,7 +124,7 @@ def get_files(master_url, pr_url, headers):
     """
     Returns the contents of the current version of the file and
     of the modified version of the file in a tuple.
-    
+
     Args:
         master_url (str): URL to the current version of the file
         pr_url (str): URL to the modified version of the file
@@ -191,7 +191,7 @@ def get_deployment_changes(versions_dict, token, is_nde_portal):
     """
     Uses the gen3git utility to get the release notes between the old and new
     versions for each service, and returns the deployment changes only.
-    
+
     Args:
         versions_dict (dict):
             {

--- a/gen3utils/etl/etl_validator.py
+++ b/gen3utils/etl/etl_validator.py
@@ -327,12 +327,10 @@ def validate_mapping(dictionary_url, mapping_file, manifest):
     tube_version = get_manifest_version(
         manifest["versions"], "tube", release_tag_are_branches=False
     )
-    if tube_version >= version.parse("0.4.0") or tube_version >= version.parse(
-        "2020.10"
-    ):
-        underscore = True
-    else:
-        underscore = False
+    underscore = False
+    if tube_version is not None:
+        if tube_version >= version.parse("0.4.0") or tube_version >= version.parse("2020.10"):
+            underscore = True
 
     recorded_errors = check_mapping_format(mappings, [])
     if len(recorded_errors) > 0:

--- a/gen3utils/etl/etl_validator.py
+++ b/gen3utils/etl/etl_validator.py
@@ -3,7 +3,7 @@ from packaging import version
 import yaml
 import re
 
-from gen3utils.manifest.manifest_validator import get_manifest_version
+from gen3utils.manifest.manifest_validator import get_manifest_version, is_release_tag
 from gen3utils.etl.dd_utils import init_dictionary
 from gen3utils.errors import MappingError, PropertiesError, PathError, FieldError
 
@@ -329,7 +329,9 @@ def validate_mapping(dictionary_url, mapping_file, manifest):
     )
     underscore = False
     if tube_version is not None:
-        if tube_version >= version.parse("0.4.0") or tube_version >= version.parse("2020.10"):
+        if not is_release_tag(tube_version) and tube_version >= version.parse("0.4.0"):
+            underscore = True
+        elif tube_version >= version.parse("2020.10"):
             underscore = True
 
     recorded_errors = check_mapping_format(mappings, [])

--- a/gen3utils/main.py
+++ b/gen3utils/main.py
@@ -60,7 +60,7 @@ def validate_etl_mapping(etl_mapping_file, manifest_file):
             return
 
         print("  Using dictionary: {}".format(dictionary_url))
-        recorded_errors = validate_mapping(dictionary_url, etl_mapping_file)
+        recorded_errors = validate_mapping(dictionary_url, etl_mapping_file, manifest)
 
         if recorded_errors:
             print("  ETL mapping validation failed:")

--- a/gen3utils/manifest/manifest_validator.py
+++ b/gen3utils/manifest/manifest_validator.py
@@ -145,6 +145,17 @@ def get_manifest_version(manifest_versions, service, release_tag_are_branches=Tr
                 return service_version
 
 
+def is_release_tag(parsed_version):
+    """
+    Args:
+        parsed_version: releases.version
+    Returns:
+        bool: True if version's major number is >= 2019. This is true of
+        our current monthly release versions (e.g. 2020.05, 2019.11) but not
+        true of our standard semver versions (e.g. 2.33.0)
+    """
+    return parsed_version >= version.parse("2019.0")
+
 def version_is_branch(version, release_tag_are_branches=True):
     """
     Args:

--- a/gen3utils/manifest/manifest_validator.py
+++ b/gen3utils/manifest/manifest_validator.py
@@ -156,6 +156,7 @@ def is_release_tag(parsed_version):
     """
     return parsed_version >= version.parse("2019.0")
 
+
 def version_is_branch(version, release_tag_are_branches=True):
     """
     Args:

--- a/gen3utils/manifest/manifest_validator.py
+++ b/gen3utils/manifest/manifest_validator.py
@@ -43,7 +43,7 @@ def validate_manifest(manifest, validation_requirement):
 
 def validate_manifest_block(manifest, blocks_requirements):
     """
-    Validates blocks in cdis-manifest. 
+    Validates blocks in cdis-manifest.
 
     Args:
         manifest (dict): Contents of manifest.json file.
@@ -117,10 +117,10 @@ def validate_manifest_block(manifest, blocks_requirements):
     return ok
 
 
-def get_manifest_version(manifest_versions, service):
+def get_manifest_version(manifest_versions, service, release_tag_are_branches=True):
     """
     Get the service version from cdis-manifest
-        Arg: 
+        Arg:
             service: microservice name
             manifest_versions: the versions block from manifest.json
         Return:
@@ -132,7 +132,7 @@ def get_manifest_version(manifest_versions, service):
             # calling get_manifest_version()! it should never happen
             service_line = manifest_versions[service]
             service_version = service_line.split(":")[1]
-            if version_is_branch(service_version):
+            if version_is_branch(service_version, release_tag_are_branches):
                 logger.warning(
                     "{} is on a branch ({}): not validating".format(
                         service, service_version
@@ -174,7 +174,7 @@ def version_is_branch(version, release_tag_are_branches=True):
 
 def versions_validation(manifest_versions, versions_requirements):
     """
-    Validates versions in cdis-manifest 
+    Validates versions in cdis-manifest
 
     Arg:
         manifest_versions: manifest.json "versions" section
@@ -249,16 +249,16 @@ def version_requirement_validation(
     service_requirement, requirement_key_list, versions_manifest, current_validation
 ):
     """
-    Validates version matches the requirement for a specific service 
+    Validates version matches the requirement for a specific service
 
     Args:
-    service_requirement: service name and its version requirement 
-    requirement_key_list: list of service name which need validation 
+    service_requirement: service name and its version requirement
+    requirement_key_list: list of service name which need validation
     versions_manfiest: versions block from manifest
     current_validation (str): service name and version that are currently being validated
 
     Return:
-        ok(bool): whether the validation succeeded. 
+        ok(bool): whether the validation succeeded.
     """
     ok = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ def etl_mapping_validation_dict():
 def etl_mapping_validation_mapping():
     return "tests/data/etlMapping.yaml"
 
+
 @pytest.fixture(scope="session")
 def etl_mapping_validation_manifest():
     with open("tests/data/manifest.json") as f:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import yaml
+import json
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -24,6 +25,11 @@ def etl_mapping_validation_dict():
 @pytest.fixture(scope="session")
 def etl_mapping_validation_mapping():
     return "tests/data/etlMapping.yaml"
+
+@pytest.fixture(scope="session")
+def etl_mapping_validation_manifest():
+    with open("tests/data/manifest.json") as f:
+        return json.load(f)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_etl_mapping_validation.py
+++ b/tests/test_etl_mapping_validation.py
@@ -3,24 +3,24 @@ import yaml
 from gen3utils.etl.etl_validator import validate_mapping
 
 
-def test_pass_validation(etl_mapping_validation_dict, etl_mapping_validation_mapping):
+def test_pass_validation(etl_mapping_validation_dict, etl_mapping_validation_mapping, etl_mapping_validation_manifest):
     errors = validate_mapping(
-        etl_mapping_validation_dict, etl_mapping_validation_mapping
+        etl_mapping_validation_dict, etl_mapping_validation_mapping, etl_mapping_validation_manifest
     )
     assert len(errors) == 0
 
 
 def test_fail_validation(
-    etl_mapping_validation_dict, etl_mapping_validation_mapping_failed
+    etl_mapping_validation_dict, etl_mapping_validation_mapping_failed, etl_mapping_validation_manifest
 ):
     errors = validate_mapping(
-        etl_mapping_validation_dict, etl_mapping_validation_mapping_failed
+        etl_mapping_validation_dict, etl_mapping_validation_mapping_failed, etl_mapping_validation_manifest
     )
     assert len(errors) == 5
 
 
-def test_fail_format(etl_mapping_validation_dict, etl_mapping_validation_format_failed):
+def test_fail_format(etl_mapping_validation_dict, etl_mapping_validation_format_failed, etl_mapping_validation_manifest):
     errors = validate_mapping(
-        etl_mapping_validation_dict, etl_mapping_validation_format_failed
+        etl_mapping_validation_dict, etl_mapping_validation_format_failed, etl_mapping_validation_manifest
     )
     assert len(errors) == 2

--- a/tests/test_etl_mapping_validation.py
+++ b/tests/test_etl_mapping_validation.py
@@ -3,24 +3,40 @@ import yaml
 from gen3utils.etl.etl_validator import validate_mapping
 
 
-def test_pass_validation(etl_mapping_validation_dict, etl_mapping_validation_mapping, etl_mapping_validation_manifest):
+def test_pass_validation(
+    etl_mapping_validation_dict,
+    etl_mapping_validation_mapping,
+    etl_mapping_validation_manifest,
+):
     errors = validate_mapping(
-        etl_mapping_validation_dict, etl_mapping_validation_mapping, etl_mapping_validation_manifest
+        etl_mapping_validation_dict,
+        etl_mapping_validation_mapping,
+        etl_mapping_validation_manifest,
     )
     assert len(errors) == 0
 
 
 def test_fail_validation(
-    etl_mapping_validation_dict, etl_mapping_validation_mapping_failed, etl_mapping_validation_manifest
+    etl_mapping_validation_dict,
+    etl_mapping_validation_mapping_failed,
+    etl_mapping_validation_manifest,
 ):
     errors = validate_mapping(
-        etl_mapping_validation_dict, etl_mapping_validation_mapping_failed, etl_mapping_validation_manifest
+        etl_mapping_validation_dict,
+        etl_mapping_validation_mapping_failed,
+        etl_mapping_validation_manifest,
     )
     assert len(errors) == 5
 
 
-def test_fail_format(etl_mapping_validation_dict, etl_mapping_validation_format_failed, etl_mapping_validation_manifest):
+def test_fail_format(
+    etl_mapping_validation_dict,
+    etl_mapping_validation_format_failed,
+    etl_mapping_validation_manifest,
+):
     errors = validate_mapping(
-        etl_mapping_validation_dict, etl_mapping_validation_format_failed, etl_mapping_validation_manifest
+        etl_mapping_validation_dict,
+        etl_mapping_validation_format_failed,
+        etl_mapping_validation_manifest,
     )
     assert len(errors) == 2


### PR DESCRIPTION
### New Features

### Breaking Changes


### Bug Fixes
- Update etlMapping validation to work with tube >= 0.4.0 / 2020.10, which has a breaking change adding underscores to `{doc_type}_id` fields. https://github.com/uc-cdis/tube/releases/tag/0.4.0


### Improvements


### Dependency updates


### Deployment changes

