### PR TITLE
fix ETL mapping validation TypeError

### DIFF
--- a/gen3utils/etl/etl_validator.py
+++ b/gen3utils/etl/etl_validator.py
@@ -3,7 +3,7 @@ from packaging import version
 import yaml
 import re
 
-from gen3utils.manifest.manifest_validator import get_manifest_version, is_release_tag
+from gen3utils.manifest.manifest_validator import get_manifest_version
 from gen3utils.etl.dd_utils import init_dictionary
 from gen3utils.errors import MappingError, PropertiesError, PathError, FieldError
 
@@ -317,6 +317,18 @@ def check_mapping_constraints(mappings, model, recorded_errors, underscore):
     return recorded_errors
 
 
+def is_release_tag(parsed_version):
+    """
+    Args:
+        parsed_version: releases.version
+    Returns:
+        bool: True if version's major number is >= 2019. This is true of
+        our current monthly release versions (e.g. 2020.05, 2019.11) but not
+        true of our standard semver versions (e.g. 2.33.0)
+    """
+    return parsed_version >= version.parse("2019.0")
+
+
 def validate_mapping(dictionary_url, mapping_file, manifest):
     dictionary, model = init_dictionary(dictionary_url)
     with open(mapping_file) as f:
@@ -328,7 +340,7 @@ def validate_mapping(dictionary_url, mapping_file, manifest):
         manifest["versions"], "tube", release_tag_are_branches=False
     )
     underscore = False
-    if tube_version is not None:
+    if tube_version is not None and type(tube_version) != str:  # str if branch
         if not is_release_tag(tube_version) and tube_version >= version.parse("0.4.0"):
             underscore = True
         elif tube_version >= version.parse("2020.10"):

--- a/gen3utils/manifest/manifest_validator.py
+++ b/gen3utils/manifest/manifest_validator.py
@@ -125,6 +125,7 @@ def get_manifest_version(manifest_versions, service, release_tag_are_branches=Tr
             manifest_versions: the versions block from manifest.json
         Return:
             parsed microservice version (or None if service not in manifest)
+            (or version string if unable to parse or version is a branch)
     """
     for manifest_version in manifest_versions:
         if manifest_version == service:
@@ -134,7 +135,7 @@ def get_manifest_version(manifest_versions, service, release_tag_are_branches=Tr
             service_version = service_line.split(":")[1]
             if version_is_branch(service_version, release_tag_are_branches):
                 logger.warning(
-                    "{} is on a branch ({}): not validating".format(
+                    "{} is on a branch ({}): not validating, returning string type".format(
                         service, service_version
                     )
                 )
@@ -142,19 +143,12 @@ def get_manifest_version(manifest_versions, service, release_tag_are_branches=Tr
             try:
                 return version.parse(service_version)
             except:
+                logger.warning(
+                    "Cannot parse version '{}', returning string type".format(
+                        service_version
+                    )
+                )
                 return service_version
-
-
-def is_release_tag(parsed_version):
-    """
-    Args:
-        parsed_version: releases.version
-    Returns:
-        bool: True if version's major number is >= 2019. This is true of
-        our current monthly release versions (e.g. 2020.05, 2019.11) but not
-        true of our standard semver versions (e.g. 2.33.0)
-    """
-    return parsed_version >= version.parse("2019.0")
 
 
 def version_is_branch(version, release_tag_are_branches=True):


### PR DESCRIPTION
https://travis-ci.com/github/uc-cdis/gitops-qa/builds/206063791
```
ETL mapping validation for jenkins-blood.planx-pla.net
  Using dictionary: https://s3.amazonaws.com/dictionary-artifacts/bpadictionary/develop/schema.json
[2020-12-02 21:27:21,017][validate-manifest][WARNING] tube is on a branch (master): not validating
...
packages/gen3utils/manifest/manifest_validator.py", line 157, in is_release_tag
    return parsed_version >= version.parse("2019.0")
TypeError: '>=' not supported between instances of 'str' and 'Version'
```

### Bug Fixes
- Fix ETL mapping validation TypeError
