### PR TITLE
chore(qa): Temporary workaround for etl validation issue

### DIFF
--- a/gen3utils/etl/etl_validator.py
+++ b/gen3utils/etl/etl_validator.py
@@ -131,8 +131,12 @@ def validate_prop(
 
 def validate_joining_src(json_obj, recorded_errors, joining_props):
     src = json_obj.get("src", json_obj.get("name"))
+    alternate_src = json_obj.get("alternate_src", json_obj.get("name"))
     if src is not None:
         if src not in joining_props:
+            if alternate_src in joining_props:
+                print("WARN: Utilizing alternate src")
+                return
             recorded_errors.append(
                 FieldError(
                     'src field "{}" (declared in "{}") is not found in joining index.'.format(


### PR DESCRIPTION
The following issue is currently blocking bdcat preprod releases:
```
[2021-01-04 19:59:20,223][ gen3utils][  ERROR]   ETL mapping validation failed:
[2021-01-04 19:59:20,224][ gen3utils][  ERROR]   - Field error: src field "file_id" (declared in "{'name': 'file_count', 'src': 'file_id', 'fn': 'count'}") is not found in joining index.
```

The ETL Validation expects an underscore prefixed `_file_id` as the environment is running `tube:2020.12`.
However, there seems to be an issue with Tube's backwards compatibility and the ETL is only working with a non-underscore-prefixed `file_id`. We are now in a situation where:
- Adding the underscore prefix fixes the static ETL Validation  but it breaks the actual ETL operation in BDCat preprod.
- Removing the underscore prefix breaks the static ETL Validation  but it fixes the actual ETL operation in BDCat preprod.

So this temporary workaround only applies to environments that are facing this anomaly.

How to use -> Just add an `alternate_src` parameter to your YAML:
e.g.,
```
          - name: file_count
            src: file_id
            alternate_src: _file_id
            fn: count
```