### PR TITLE
Empty 'graphql.boardCounts' is valid

### DIFF
--- a/gen3utils/gitops/gitops_validator.py
+++ b/gen3utils/gitops/gitops_validator.py
@@ -44,8 +44,8 @@ def validate_gitops_syntax(gitops):
     ok = assert_and_log(graphql, FieldSyntaxError("graphql"))
 
     if graphql:
-        boardcounts = graphql.get("boardCounts")
-        ok = ok and assert_and_log(boardcounts, FieldSyntaxError("graphql.boardCounts"))
+        ok = ok and assert_and_log("boardCounts" in graphql, FieldSyntaxError("graphql.boardCounts"))
+        boardcounts = graphql["boardCounts"]
         if boardcounts:
             for item in boardcounts:
                 checks = ["graphql", "name", "plural"]

--- a/gen3utils/gitops/gitops_validator.py
+++ b/gen3utils/gitops/gitops_validator.py
@@ -45,7 +45,7 @@ def validate_gitops_syntax(gitops):
 
     if graphql:
         ok = ok and assert_and_log("boardCounts" in graphql, FieldSyntaxError("graphql.boardCounts"))
-        boardcounts = graphql["boardCounts"]
+        boardcounts = graphql.get("boardCounts", [])
         if boardcounts:
             for item in boardcounts:
                 checks = ["graphql", "name", "plural"]

--- a/gen3utils/gitops/gitops_validator.py
+++ b/gen3utils/gitops/gitops_validator.py
@@ -44,7 +44,9 @@ def validate_gitops_syntax(gitops):
     ok = assert_and_log(graphql, FieldSyntaxError("graphql"))
 
     if graphql:
-        ok = ok and assert_and_log("boardCounts" in graphql, FieldSyntaxError("graphql.boardCounts"))
+        ok = ok and assert_and_log(
+            "boardCounts" in graphql, FieldSyntaxError("graphql.boardCounts")
+        )
         boardcounts = graphql.get("boardCounts", [])
         if boardcounts:
             for item in boardcounts:

--- a/gen3utils/gitops/gitops_validator.py
+++ b/gen3utils/gitops/gitops_validator.py
@@ -53,8 +53,9 @@ def validate_gitops_syntax(gitops):
                 checks = ["graphql", "name", "plural"]
                 ok = check_required_fields("graphql.boardCounts", checks, item, ok)
 
-        chartcounts = graphql.get("chartCounts")
-        ok = ok and assert_and_log(chartcounts, FieldSyntaxError("graphql.chartCounts"))
+        ok = ok and assert_and_log(
+            "chartcounts" in graphql, FieldSyntaxError("graphql.chartCounts")
+        )
 
     components = gitops.get("components")
     ok = ok and assert_and_log(components, FieldSyntaxError("components"))


### PR DESCRIPTION
### Improvements
- gitops.json validator: Empty 'graphql.boardCounts' and  'graphql.chartCounts' are valid
- gitops.json validator: Explorer config validation fixes