### PR TITLE
fix(release-automation): Translate awshelper svc name to repo name cl…

### DIFF
--- a/gen3utils/deployment_changes/generate_comment.py
+++ b/gen3utils/deployment_changes/generate_comment.py
@@ -29,6 +29,7 @@ IGNORED_SERVICES = [
 # block is not the same as the repo name. services that are not
 # listed here are assumed to be in repo uc-cdis/<service name>.
 SERVICE_TO_REPO = {
+    "awshelper": "cloud-automation",
     "dashboard": "gen3-statics",
     "portal": "data-portal",
     "revproxy": "docker-nginx",


### PR DESCRIPTION
This addresses the issue where `gen3utils` can't find the corresponding github repo name for the `awshelper` service.