### PR TITLE
Do not exit if GITHUB_TOKEN is missing

### DIFF
--- a/gen3utils/deployment_changes/generate_comment.py
+++ b/gen3utils/deployment_changes/generate_comment.py
@@ -3,6 +3,7 @@ import os
 from packaging import version
 import re
 import requests
+import sys
 
 from cdislogging import get_logger
 import gen3git
@@ -51,8 +52,15 @@ def comment_deployment_changes_on_pr(repository, pull_request_number):
         repository (str): "<user>/<repo>"
         pull_request_number (str)
     """
-    token = os.environ["GITHUB_TOKEN"]
-    headers = {"Authorization": "token {}".format(token)}
+    if "GITHUB_TOKEN" in os.environ:
+        token = os.environ["GITHUB_TOKEN"]
+        headers = {"Authorization": "token {}".format(token)}
+    else:
+        logger.warning(
+            "Missing GITHUB_TOKEN: NOT commenting deployment changes on pull request. Continuing; but might fail later if the PR is not accessible."
+        )
+        token = None
+        headers = {}
 
     repository = repository.strip("/")
     base_url = "https://api.github.com/repos/{}".format(repository)

--- a/gen3utils/main.py
+++ b/gen3utils/main.py
@@ -2,7 +2,6 @@ import click
 import json
 import multiprocessing
 import os
-import sys
 import yaml
 
 from cdislogging import get_logger
@@ -57,9 +56,8 @@ def validate_portal_config(
         for err in recorded_errors:
             logger.error("  - {}".format(err))
         if repository and pull_request_number:
-            if not "GITHUB_TOKEN" in os.environ:
-                logger.error("Exiting: Missing GITHUB_TOKEN")
-                sys.exit(1)
+            if "GITHUB_TOKEN" in os.environ:
+                logger.warning("Missing GITHUB_TOKEN: not commenting on pull request.")
             message_header = "{}\n :x: etlMapping.yaml - gitops.json mismatch".format(
                 hostname
             )
@@ -136,11 +134,6 @@ def post_deployment_changes(repository, pull_request_number):
     """
     Comment on a pull request with any deployment changes when updating manifest services. Also comment a warning if a service is on a branch.
     """
-
-    if not "GITHUB_TOKEN" in os.environ:
-        logger.error("Exiting: Missing GITHUB_TOKEN")
-        sys.exit(1)
-
     comment_deployment_changes_on_pr(repository, pull_request_number)
 
 


### PR DESCRIPTION

### Improvements
- "post-deployment-changes" and "validate-portal-config" commands: do not exit if GITHUB_TOKEN is missing
