### PR TITLE
Use booleans instead of true/false strings

### DIFF
--- a/gen3utils/manifest/manifest_validator.py
+++ b/gen3utils/manifest/manifest_validator.py
@@ -64,8 +64,8 @@ def validate_manifest_block(manifest, blocks_requirements):
                 manifest["versions"], service_name
             )
             is_branch = version_is_branch(block_requirement_version)
-            should_check_has = "has" in block and not is_branch
-            if "version" in block and not is_branch:
+            should_check_has = type(block) == dict and "has" in block and not is_branch
+            if type(block) == dict and "version" in block and not is_branch:
                 # If we have version requirement for a service, min or max is required.
                 # We are not validating branch or master branch
                 # min: Version in manifest is equal or greater than the verson in validation_config
@@ -99,13 +99,13 @@ def validate_manifest_block(manifest, blocks_requirements):
                         service_name in manifest
                         and block["has"] in manifest[service_name]
                         or service_name not in manifest
-                        and block.get("optional") == "true",
+                        and block.get("optional"),
                         error_msg,
                     )
                     and ok
                 )
 
-            if block == "true":
+            if block:
                 # Validation to check if a block exists in cdis-manifest
                 ok = (
                     assert_and_log(

--- a/gen3utils/manifest/validation_config.yaml
+++ b/gen3utils/manifest/validation_config.yaml
@@ -12,7 +12,7 @@ avoid:
 # BLOCK VALIDATION #
 ####################
 # Validation for the manifest blocks required by some services
-# The version should contains at least min or max.
+# The version should contain at least min or max.
 # /!\ max is < not <=. min is >=
 
 block:
@@ -26,11 +26,11 @@ block:
   hatchery:
     has: sidecar
     # hatchery may be in its own hatchery.json file
-    optional: "true"
+    optional: True
   # sower requires a sower block
-  sower: "true"
+  sower: True
   # guppy requires a guppy block
-  guppy: "true"
+  guppy: True
 
 
 ######################


### PR DESCRIPTION


### Improvements
- Use booleans in manifest validation configuration instead of true/false strings
