### PR TITLE
fix: footerLogos validation

### DIFF
--- a/gen3utils/gitops/gitops_validator.py
+++ b/gen3utils/gitops/gitops_validator.py
@@ -75,7 +75,9 @@ def validate_gitops_syntax(gitops):
 
         # footerLogos is optional, but when present, it must be an array (list)
         footerLogos = components.get("footerLogos", [])
-        ok = ok and assert_and_log(isinstance(footerLogos, list), FieldError("footerLogos"))
+        ok = ok and assert_and_log(
+            isinstance(footerLogos, list), FieldError("footerLogos")
+        )
 
     explorer_enabled = gitops.get("featureFlags", {}).get("explorer", True)
     explorerconfig = gitops.get("explorerConfig")

--- a/gen3utils/gitops/gitops_validator.py
+++ b/gen3utils/gitops/gitops_validator.py
@@ -73,6 +73,10 @@ def validate_gitops_syntax(gitops):
                     "components.index.homepage", checks, item, ok
                 )
 
+        # footerLogos is optional, but when present, it must be an array (list)
+        footerLogos = components.get("footerLogos", [])
+        ok = ok and assert_and_log(isinstance(footerLogos, list), FieldError("footerLogos"))
+
     explorer_enabled = gitops.get("featureFlags", {}).get("explorer", True)
     explorerconfig = gitops.get("explorerConfig")
     configs = []

--- a/gen3utils/gitops/gitops_validator.py
+++ b/gen3utils/gitops/gitops_validator.py
@@ -76,7 +76,8 @@ def validate_gitops_syntax(gitops):
         # footerLogos is optional, but when present, it must be an array (list)
         footerLogos = components.get("footerLogos", [])
         ok = ok and assert_and_log(
-            isinstance(footerLogos, list), FieldError("footerLogos")
+            isinstance(footerLogos, list),
+            FieldError("footerLogos must be an array if presents in the config"),
         )
 
     explorer_enabled = gitops.get("featureFlags", {}).get("explorer", True)


### PR DESCRIPTION


### Bug Fixes
- `footerLogos` in portal config is optional, but when present, it must be an array (list)
