### PR TITLE
Fix KeyError

### DIFF
--- a/gen3utils/manifest/manifest_validator.py
+++ b/gen3utils/manifest/manifest_validator.py
@@ -22,7 +22,8 @@ def validate_manifest(manifest, validation_requirement):
     if hostname in validation_requirement.get("avoid", []):
         services_to_skip = validation_requirement["avoid"][hostname]
         for s in services_to_skip:
-            del manifest["versions"][s]
+            if s in manifest["versions"]:
+                del manifest["versions"][s]
 
     ok = True
     if "block" in validation_requirement:


### PR DESCRIPTION
```
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/gen3utils/manifest/manifest_validator.py", line 25, in validate_manifest
    del manifest["versions"][s]
KeyError: 'sower'
```

### Bug Fixes
- Fix manifest validator KeyError when the service to skip is not deployed
