### PR TITLE
Fix 'ok' logic

### DIFF
--- a/gen3utils/main.py
+++ b/gen3utils/main.py
@@ -71,7 +71,7 @@ def validate_portal_config(
 
     if not ok:
         raise AssertionError(
-            "Portal configuration mapping validation failed. See errors in previous logs."
+            "Portal configuration validation failed. See errors in previous logs."
         )
     else:
         logger.info("  OK!")


### PR DESCRIPTION

### Improvements
- Use `X and ok` instead of `ok and X` in tests so that all the checks run even if an earlier check has failed
- Document why mismatches between the ETL mapping and the portal config are reported in a PR comment but don't make the tests fail
