### PR TITLE
Fix logic to check if service is on a branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - secure: KY3stltR4M1obId8R1s98gUYdxCqZdfnUMJ+5qRiXIdMy+ZsyHlZ/cVtjpIqPBkmDVXRpC9sp66j7ipNl/WEA1Su5mkQSuec/h2d9aN57MrzXClPs4qSadyCvOfA8wjfKbuw6eTBvX6WF7UA6eC4nv07q+sAp2CuaMRm8fi5jbk9fcF+3QCFmd5ORuBXoVBRnU3lvsf3ih8l0ESxFfgjAfsuDoXYV9/8eyhknn9rpSHuX1lP0Ut/+Cs40bF8M3ujknA8GfdkMF9dRdSOvqyX7Jz4A/AiXKG69ZJXxR1XdZuZmdlMytjBw/XrSjNm/m2/gYca+MAPGA1/FEO20yf7a9VItJVBppO+QJ6QFZ+gB0vz7lRy88grAk1iFwi0+kMmXgcInjlb+iStw+MIbdBTzPW7AFkIEDqyN5XKhJgah8cFvYE0GOP/ROXr3AgBEvT3yj7kO+fHE7bmCkpjEaTIKkosb+/jTO3ty8YWHjT7NVaNFmX5i6gxKa3jbiSLtPkEsByNZOYtuIOWIkvnLOVNiC9Y9E6ZN0F+qiKinuDYqvmxx+HvHhJmjO+/E5DSh0cqgN3OFYUB/1kVEI/B+MaX/KbVdAA8KCdXvaClURcbBSZlD4nqOsGUcDmGbri/lMmG/9ozVrmlwyfZ6cfRapmBRouC6EcQ2FGLqZe4r3LYngc= # pragma: allowlist secret
 install:
 - pip install poetry
-- poetry install -vv --no-interaction
+- poetry install -vv --no-interaction --no-cache
 script:
 - poetry run pytest -vv ./tests
 before_deploy:

--- a/gen3utils/deployment_changes/generate_comment.py
+++ b/gen3utils/deployment_changes/generate_comment.py
@@ -359,6 +359,11 @@ def get_downgraded_services(compared_versions):
     """
     downgraded_services = set()
     for service, versions in compared_versions.items():
+        if version_is_branch(
+            versions["old"], release_tag_are_branches=False
+        ) or version_is_branch(versions["new"], release_tag_are_branches=False):
+            # we can't compare branches
+            continue
         old_is_monthly = version_is_monthly_release(versions["old"])
         new_is_monthly = version_is_monthly_release(versions["new"])
         if old_is_monthly != new_is_monthly:
@@ -376,7 +381,10 @@ def check_services_on_branch(versions_block):
     services_on_branch = []
     for service in versions_block:
         version = versions_block.get(service)
-        if "quay.io/cdis" not in version or len(version.split(":")) < 2:
+        if (
+            "quay.io/cdis" not in version
+            and "dkr.ecr.us-east-1.amazonaws.com" not in version
+        ) or len(version.split(":")) < 2:
             # ignore non-CTDS repos.
             # version without ":" is not usable.
             continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gen3utils"
-version = "0.10.1"
+version = "0.10.2"
 description = "Utils for Gen3 Commons management"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"

--- a/tests/test_deployment_changes.py
+++ b/tests/test_deployment_changes.py
@@ -71,7 +71,7 @@ def test_services_on_branch():
 def test_downgraded_services():
     compared_versions = {
         "upgraded-semver": {"old": "1.0", "new": "2.0.0"},
-        "downgraded-semver": {"old": "3", "new": "2.0.0"},
+        "downgraded-semver": {"old": "3.0", "new": "2.0.0"},
         "upgraded-monthly": {"old": "2022.02", "new": "2022.03"},
         "downgraded-monthly": {"old": "2022.02", "new": "2021.03"},
         "upgraded-mixed": {"old": "2020.03", "new": "3.3.1"},


### PR DESCRIPTION

### Bug Fixes
- Fix `get_downgraded_services()` to check if services are on a branch - if so, we can't compare the versions
- Fix `check_services_on_branch()` to recognize both Quay and ECR images as CTDS repos instead of just Quay
